### PR TITLE
Fix unclosed parentheses in Package-Requires headers

### DIFF
--- a/org-dynamic-bullets.el
+++ b/org-dynamic-bullets.el
@@ -168,6 +168,7 @@ to be refreshed. Two options are:
 
 ;;;; Minor mode
 
+;;;###autoload
 (define-minor-mode org-dynamic-bullets-mode
   "Display orgmode trees."
   nil

--- a/org-dynamic-bullets.el
+++ b/org-dynamic-bullets.el
@@ -5,7 +5,7 @@
 ;; Author: Jeff Filipovits <jrfilipovits@gmail.com>
 ;; Url: https://github.com/legalnonsense/org-dynamic-bullets
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "26.1") (org "9.0")
+;; Package-Requires: ((emacs "26.1") (org "9.0"))
 ;;
 ;; Keywords: Org, outline
 

--- a/org-visual-indent.el
+++ b/org-visual-indent.el
@@ -5,7 +5,7 @@
 ;; Author: Jeff Filipovits <jrfilipovits@gmail.com>
 ;; Url: https://github.com/legalnonsense/org-dynamic-bullets
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "26.1") (org "9.0")
+;; Package-Requires: ((emacs "26.1") (org "9.0"))
 ;;
 ;; Keywords: Org, outline
 

--- a/org-visual-indent.el
+++ b/org-visual-indent.el
@@ -258,6 +258,7 @@ The function stands in place of `org-indent--compute-prefixes'."
        level indentation heading)
     (funcall func level indentation heading)))
 
+;;;###autoload
 (define-minor-mode org-visual-indent-mode 
   "Add vertical lines to `org-indent'."
   nil


### PR DESCRIPTION
This is just a syntactic error. It can be problematic when you package these packages.